### PR TITLE
add gatsby v4 as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "author": "Abraham White <abelincoln.white@gmail.com>",
   "license": "MIT",
   "peerDependencies": {
-    "gatsby": "^3.6.2",
+    "gatsby": "^3.6.2 || ^4.0.0",
     "graphql": "^14.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Using Gatsby v4, `gatsby-transformer-remark-frontmatter` works great but I get the following warning: 
`warn Plugin gatsby-transformer-remark-frontmatter is not compatible with your gatsby version 4.13.1 - It requires
gatsby@^3.6.2`